### PR TITLE
Remove NFTS endpoint in favor of single nft endpoint

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -2,10 +2,6 @@ import { Router } from 'worktop';
 import * as Cache from 'worktop/cache';
 import * as CORS from 'worktop/cors';
 
-interface NFTs {
-  ids: string[];
-}
-
 interface NFT {
   name: string;
   description: string;
@@ -31,22 +27,6 @@ API.add('GET', '/nft/:id', async (req, res) => {
   const { params: { id } } = req
   res.setHeader('Cache-Control', 'public, max-age=60');
   res.send(200, constructNft(id));
-});
-
-API.add('POST', '/nfts', async (req, res) => {
-  try {
-    var input = await req.body<NFTs>();
-  } catch (err) {
-    return res.send(400, 'Error parsing request body');
-  }
-
-  if (!input || !input.ids) {
-    return res.send(422, { ids: 'required' });
-  }
-
-  const nfts = input.ids.map(id => constructNft(id))
-
-  res.send(200, { nfts });
 });
 
 Cache.listen(API.run);

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "worker",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Originally I wanted to get the list of NFTs owned client-side, make an array and send that to the /nfts endpoint. But that would require hard coding the API endpoint instead of getting it from `tokenURI()`. So maybe, even though it's less efficient, it would make for a better example to do it this way? Then we wouldn't need this endpoint. 